### PR TITLE
Fix: return only user id than user information in JwtAuthGuard

### DIFF
--- a/src/auth/guard/jwt-auth.guard.ts
+++ b/src/auth/guard/jwt-auth.guard.ts
@@ -3,7 +3,7 @@ import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('access_token') {
-  handleRequest<TUser = any>(err: any, user: TUser, info: any): TUser {
+  handleRequest<TUser = any>(err: any, user: any, info: any): TUser {
     // TokenExpiredError 발생 시 처리
     if (info?.name === 'TokenExpiredError') {
       throw new UnauthorizedException('Your access token has expired');
@@ -13,6 +13,6 @@ export class JwtAuthGuard extends AuthGuard('access_token') {
       throw err || new UnauthorizedException('Unauthorized access');
     }
 
-    return user;
+    return user.id;
   }
 }


### PR DESCRIPTION
JwtAuthGuard에서 req.user에 userId 만 반환하도록 변경